### PR TITLE
Canvas dimensions fix

### DIFF
--- a/qr-scanner.js
+++ b/qr-scanner.js
@@ -22,8 +22,8 @@ angular.module('qrScanner', ["ng"]).directive('qrScanner', ['$interval', '$windo
       var height = attrs.height || 300;
       var width = attrs.width || 250;
 
-			var cheight = height < 500 ? 500 : height;
-			var cwidth = width < 500 ? 500 : width;
+      var cheight = height < 500 ? 500 : height;
+      var cwidth = width < 500 ? 500 : width;
 
       var video = $window.document.createElement('video');
       video.setAttribute('width', width);

--- a/qr-scanner.js
+++ b/qr-scanner.js
@@ -15,28 +15,31 @@ angular.module('qrScanner', ["ng"]).directive('qrScanner', ['$interval', '$windo
       ngVideoError: '&ngVideoError'
     },
     link: function(scope, element, attrs) {
-    
+
       window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
       navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
-    
+
       var height = attrs.height || 300;
       var width = attrs.width || 250;
-    
+
+			var cheight = height < 500 ? 500 : height;
+			var cwidth = width < 500 ? 500 : width;
+
       var video = $window.document.createElement('video');
       video.setAttribute('width', width);
       video.setAttribute('height', height);
       video.setAttribute('style', '-moz-transform:rotateY(-180deg);-webkit-transform:rotateY(-180deg);transform:rotateY(-180deg);');
       var canvas = $window.document.createElement('canvas');
       canvas.setAttribute('id', 'qr-canvas');
-      canvas.setAttribute('width', width);
-      canvas.setAttribute('height', height);
-      canvas.setAttribute('style', 'display:none;'); 
-    
+      canvas.setAttribute('width', cwidth);
+      canvas.setAttribute('height', cheight);
+      canvas.setAttribute('style', 'display:none;');
+
       angular.element(element).append(video);
       angular.element(element).append(canvas);
-      var context = canvas.getContext('2d'); 
+      var context = canvas.getContext('2d');
       var stopScan;
-    
+
       var scan = function() {
         if ($window.localMediaStream) {
           context.drawImage(video, 0, 0, 307,250);


### PR DESCRIPTION
Changed canvas dimensions to be minimum of 500x500.  This fixes the issue where the video display size is too small to successfully identify the QR code.