### PR TITLE
createObjectURL is deprecated

### DIFF
--- a/qr-scanner.js
+++ b/qr-scanner.js
@@ -49,7 +49,11 @@ angular.module('qrScanner', ["ng"]).directive('qrScanner', ['$interval', '$windo
       }
 
       var successCallback = function(stream) {
-        video.srcObject = stream
+        try{
+        	video.srcObject = stream
+        }catch (error) {
+        	video.src = (window.URL && window.URL.createObjectURL(stream)) || stream;
+        }
         $window.localMediaStream = stream;
 
         scope.video = video;

--- a/qr-scanner.js
+++ b/qr-scanner.js
@@ -15,13 +15,13 @@ angular.module('qrScanner', ["ng"]).directive('qrScanner', ['$interval', '$windo
       ngVideoError: '&ngVideoError'
     },
     link: function(scope, element, attrs) {
-    
+
       window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
       navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
-    
+
       var height = attrs.height || 300;
       var width = attrs.width || 250;
-    
+
       var video = $window.document.createElement('video');
       video.setAttribute('width', width);
       video.setAttribute('height', height);
@@ -30,13 +30,13 @@ angular.module('qrScanner', ["ng"]).directive('qrScanner', ['$interval', '$windo
       canvas.setAttribute('id', 'qr-canvas');
       canvas.setAttribute('width', width);
       canvas.setAttribute('height', height);
-      canvas.setAttribute('style', 'display:none;'); 
-    
+      canvas.setAttribute('style', 'display:none;');
+
       angular.element(element).append(video);
       angular.element(element).append(canvas);
-      var context = canvas.getContext('2d'); 
+      var context = canvas.getContext('2d');
       var stopScan;
-    
+
       var scan = function() {
         if ($window.localMediaStream) {
           context.drawImage(video, 0, 0, 307,250);
@@ -49,7 +49,7 @@ angular.module('qrScanner', ["ng"]).directive('qrScanner', ['$interval', '$windo
       }
 
       var successCallback = function(stream) {
-        video.src = (window.URL && window.URL.createObjectURL(stream)) || stream;
+        video.srcObject = stream
         $window.localMediaStream = stream;
 
         scope.video = video;


### PR DESCRIPTION
Camera could not open in any browser and throw this error: "Failed to execute 'createObjectURL' on 'URL': No function was found that matched the signature provided."

See for deprecated technique: https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL

See for Modern technique: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject



